### PR TITLE
Configure pluginManagement repositories

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,12 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id 'com.android.library' version '8.1.0'
+    }
+}
+
+rootProject.name = "permissionFlow"


### PR DESCRIPTION
## Summary
- add `settings.gradle` with pluginManagement repositories and Android plugin version

## Testing
- `gradle build` *(fails: Plugin [id: 'com.android.library'] was not found in any of the following sources)*

------
https://chatgpt.com/codex/tasks/task_b_689caf3bcc5483258d1e46bafb8908f2